### PR TITLE
Fix Norwegian translation typo

### DIFF
--- a/apps/customer-frontend/messages/no.json
+++ b/apps/customer-frontend/messages/no.json
@@ -144,7 +144,7 @@
       "confirmTransfer": "Bekreft overføring",
       "processing": "Behandler...",
       "insufficientFunds": "Utilstrekkelige midler",
-      "insufficientFundsDescription": "Denne overføringen vil resultere i negativ saldo for kilden kontoen.",
+      "insufficientFundsDescription": "Denne overføringen vil resultere i negativ saldo for kildekontoen.",
       "sepaDetails": {
         "recipient": "Mottaker",
         "bank": "Bank",


### PR DESCRIPTION
## Summary
- correct the Norwegian translation for insufficient funds description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687963c4bb1c8320bf21214d44dbaa3d